### PR TITLE
storage: Fix wrong method call when set multipart size maximum in metadata

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -302,7 +302,7 @@ func (s *Storage) metadata(opt pairStorageMetadata) (meta *StorageMeta) {
 	meta.SetAppendTotalSizeMaximum(appendTotalSizeMaximum)
 	// set multipart restrictions
 	meta.SetMultipartNumberMaximum(multipartNumberMaximum)
-	meta.SetMultipartNumberMaximum(multipartSizeMaximum)
+	meta.SetMultipartSizeMaximum(multipartSizeMaximum)
 	meta.SetMultipartSizeMinimum(multipartSizeMinimum)
 	return
 }


### PR DESCRIPTION
Fix #50 

Signed-off-by: Prnyself <281239768@qq.com>